### PR TITLE
treewide: Add parameters to control config prints

### DIFF
--- a/src/axi_llc_config.sv
+++ b/src/axi_llc_config.sv
@@ -190,7 +190,9 @@ module axi_llc_config #(
   parameter type set_asso_t = logic,
   /// Address type for the memory regions defined for caching and SPM. The same width as
   /// the address field of the AXI4+ATOP slave and master port.
-  parameter type addr_full_t = logic
+  parameter type addr_full_t = logic,
+  /// Whether to print config of LLC
+  parameter bit  PrintLlcCfg = 0
 ) (
   /// Rising-edge clock
   input logic clk_i,
@@ -593,42 +595,44 @@ module axi_llc_config #(
                              Cfg.SetAssociativity, RegWidth));
   end
 
-  initial begin : proc_llc_hello
-    @(posedge rst_ni);
-    $display("###############################################################################");
-    $display("###############################################################################");
-    $display("AXI LLC module instantiated:");
-    $display("%m");
-    $display("###############################################################################");
-    $display("Cache Size parameters:");
-    $display("Max Cache/SPM size:                (decimal): %d KiB", Cfg.SPMLength/1024);
-    $display("SetAssociativity (Number of Ways)  (decimal): %d", Cfg.SetAssociativity  );
-    $display("Number of Cache Lines per Set      (decimal): %d", Cfg.NumLines          );
-    $display("Number of Blocks per Cache Line    (decimal): %d", Cfg.NumBlocks         );
-    $display("Block Size in Bits                 (decimal): %d", Cfg.BlockSize         );
-    $display("Tag Length of AXI Address          (decimal): %d", Cfg.TagLength         );
-    $display("Index Length of AXI Address        (decimal): %d", Cfg.IndexLength       );
-    $display("Block Offset Length of AXI Address (decimal): %d", Cfg.BlockOffsetLength );
-    $display("Byte Offset Length of AXI Address  (decimal): %d", Cfg.ByteOffsetLength  );
-    $display("###############################################################################");
-    $display("AXI4 Port parameters:");
-    $display("Slave port (CPU):");
-    $display("ID   width (decimal): %d", AxiCfg.SlvPortIdWidth );
-    $display("ADDR width (decimal): %d", AxiCfg.AddrWidthFull  );
-    $display("DATA width (decimal): %d", AxiCfg.DataWidthFull  );
-    $display("STRB width (decimal): %d", AxiCfg.DataWidthFull/8);
-    $display("Master port (memory):");
-    $display("ID   width (decimal): %d", AxiCfg.SlvPortIdWidth + 1);
-    $display("ADDR width (decimal): %d", AxiCfg.AddrWidthFull     );
-    $display("DATA width (decimal): %d", AxiCfg.DataWidthFull     );
-    $display("STRB width (decimal): %d", AxiCfg.DataWidthFull/8   );
-    $display("Address mapping information:");
-    $display("Cached region Start address (hex): %h", axi_cached_rule_i.start_addr );
-    $display("Cached region End   address (hex): %h", axi_cached_rule_i.end_addr   );
-    $display("SPM    region Start address (hex): %h", axi_spm_rule_i.start_addr    );
-    $display("SPM    region End   address (hex): %h", axi_spm_rule_i.end_addr      );
-    $display("###############################################################################");
-    $display("###############################################################################");
+  if (PrintLlcCfg) begin : gen_llc_hello
+    initial begin : proc_llc_hello
+      @(posedge rst_ni);
+      $display("###############################################################################");
+      $display("###############################################################################");
+      $display("AXI LLC module instantiated:");
+      $display("%m");
+      $display("###############################################################################");
+      $display("Cache Size parameters:");
+      $display("Max Cache/SPM size:                (decimal): %d KiB", Cfg.SPMLength/1024);
+      $display("SetAssociativity (Number of Ways)  (decimal): %d", Cfg.SetAssociativity  );
+      $display("Number of Cache Lines per Set      (decimal): %d", Cfg.NumLines          );
+      $display("Number of Blocks per Cache Line    (decimal): %d", Cfg.NumBlocks         );
+      $display("Block Size in Bits                 (decimal): %d", Cfg.BlockSize         );
+      $display("Tag Length of AXI Address          (decimal): %d", Cfg.TagLength         );
+      $display("Index Length of AXI Address        (decimal): %d", Cfg.IndexLength       );
+      $display("Block Offset Length of AXI Address (decimal): %d", Cfg.BlockOffsetLength );
+      $display("Byte Offset Length of AXI Address  (decimal): %d", Cfg.ByteOffsetLength  );
+      $display("###############################################################################");
+      $display("AXI4 Port parameters:");
+      $display("Slave port (CPU):");
+      $display("ID   width (decimal): %d", AxiCfg.SlvPortIdWidth );
+      $display("ADDR width (decimal): %d", AxiCfg.AddrWidthFull  );
+      $display("DATA width (decimal): %d", AxiCfg.DataWidthFull  );
+      $display("STRB width (decimal): %d", AxiCfg.DataWidthFull/8);
+      $display("Master port (memory):");
+      $display("ID   width (decimal): %d", AxiCfg.SlvPortIdWidth + 1);
+      $display("ADDR width (decimal): %d", AxiCfg.AddrWidthFull     );
+      $display("DATA width (decimal): %d", AxiCfg.DataWidthFull     );
+      $display("STRB width (decimal): %d", AxiCfg.DataWidthFull/8   );
+      $display("Address mapping information:");
+      $display("Cached region Start address (hex): %h", axi_cached_rule_i.start_addr );
+      $display("Cached region End   address (hex): %h", axi_cached_rule_i.end_addr   );
+      $display("SPM    region Start address (hex): %h", axi_spm_rule_i.start_addr    );
+      $display("SPM    region End   address (hex): %h", axi_spm_rule_i.end_addr      );
+      $display("###############################################################################");
+      $display("###############################################################################");
+    end
   end
 `endif
 // pragma translate_on

--- a/src/axi_llc_data_way.sv
+++ b/src/axi_llc_data_way.sv
@@ -30,7 +30,9 @@ module axi_llc_data_way #(
   ///   axi_axi_llc_pkg::cache_unit_e cache_unit;   // which unit had the access
   ///   axi_data_t                    data;         // read data from the macro
   /// } way_oup_t;
-  parameter type way_oup_t = logic
+  parameter type way_oup_t = logic,
+  /// Whether to print SRAM configs.
+  parameter bit  PrintSramCfg = 0
 ) (
   /// Clock, positive edge triggered
   input logic clk_i,
@@ -121,7 +123,7 @@ module axi_llc_data_way #(
     .NumPorts   ( 32'd1                        ),
     .Latency    ( 32'd1                        ),
     .SimInit    ( "none"                       ),
-    .PrintSimCfg( 1'b1                         )
+    .PrintSimCfg( PrintSramCfg                 )
   ) i_data_sram (
     .clk_i,
     .rst_ni,

--- a/src/axi_llc_hit_miss.sv
+++ b/src/axi_llc_hit_miss.sv
@@ -46,7 +46,9 @@ module axi_llc_hit_miss #(
   /// } cnt_t;
   parameter type                       cnt_t     = logic,
   /// Way indicator, is a onehot signal with width: `Cfg.SetAssociativity`.
-  parameter type                       way_ind_t = logic
+  parameter type                       way_ind_t = logic,
+  /// Whether to print SRAM configs
+  parameter bit                        PrintSramCfg = 0
 ) (
   /// Clock, positive edge triggered.
   input  logic     clk_i,
@@ -330,10 +332,11 @@ module axi_llc_hit_miss #(
   end
 
   axi_llc_tag_store #(
-    .Cfg         ( Cfg         ),
-    .way_ind_t   ( way_ind_t   ),
-    .store_req_t ( store_req_t ),
-    .store_res_t ( store_res_t )
+    .Cfg          ( Cfg          ),
+    .way_ind_t    ( way_ind_t    ),
+    .store_req_t  ( store_req_t  ),
+    .store_res_t  ( store_res_t  ),
+    .PrintSramCfg ( PrintSramCfg )
   ) i_tag_store (
     .clk_i,
     .rst_ni,

--- a/src/axi_llc_reg_wrap.sv
+++ b/src/axi_llc_reg_wrap.sv
@@ -181,6 +181,8 @@ module axi_llc_reg_wrap #(
   parameter type reg_resp_t      = logic,
   /// Full AXI4+ATOP Port address decoding rule
   parameter type rule_full_t    = axi_pkg::xbar_rule_64_t,
+  /// Whether to print SRAM configs
+  parameter bit  PrintSramCfg   = 0,
   /// Dependent parameter, do **not** overwrite!
   /// Address type of the AXI4+ATOP ports.
   /// The address fields of the rule type have to be the same.
@@ -272,7 +274,8 @@ module axi_llc_reg_wrap #(
     .slv_resp_t       ( slv_resp_t            ),
     .mst_req_t        ( mst_req_t             ),
     .mst_resp_t       ( mst_resp_t            ),
-    .rule_full_t      ( rule_full_t           )
+    .rule_full_t      ( rule_full_t           ),
+    .PrintSramCfg     ( PrintSramCfg          )
   ) i_axi_llc_top_raw (
     .clk_i,
     .rst_ni,

--- a/src/axi_llc_top.sv
+++ b/src/axi_llc_top.sv
@@ -177,6 +177,10 @@ module axi_llc_top #(
   parameter type mst_resp_t     = logic,
   /// Full AXI4+ATOP Port address decoding rule
   parameter type rule_full_t    = axi_pkg::xbar_rule_64_t,
+  /// Whether to print SRAM configs
+  parameter bit  PrintSramCfg   = 0,
+  /// Whether to print config of LLC
+  parameter bit  PrintLlcCfg    = 0,
   /// Dependent parameter, do **not** overwrite!
   /// Address type of the AXI4+ATOP ports.
   /// The address fields of the rule type have to be the same.
@@ -402,7 +406,8 @@ module axi_llc_top #(
     .desc_t         ( llc_desc_t    ),
     .rule_full_t    ( rule_full_t   ),
     .set_asso_t     ( way_ind_t     ),
-    .addr_full_t    ( axi_addr_t    )
+    .addr_full_t    ( axi_addr_t    ),
+    .PrintLlcCfg    ( PrintLlcCfg   )
   ) i_llc_config (
     .clk_i             ( clk_i                                  ),
     .rst_ni            ( rst_ni                                 ),
@@ -562,12 +567,13 @@ module axi_llc_top #(
   );
 
   axi_llc_hit_miss #(
-    .Cfg       ( Cfg        ),
-    .AxiCfg    ( AxiCfg     ),
-    .desc_t    ( llc_desc_t ),
-    .lock_t    ( lock_t     ),
-    .cnt_t     ( cnt_t      ),
-    .way_ind_t ( way_ind_t  )
+    .Cfg          ( Cfg          ),
+    .AxiCfg       ( AxiCfg       ),
+    .desc_t       ( llc_desc_t   ),
+    .lock_t       ( lock_t       ),
+    .cnt_t        ( cnt_t        ),
+    .way_ind_t    ( way_ind_t    ),
+    .PrintSramCfg ( PrintSramCfg )
   ) i_hit_miss_unit (
     .clk_i,
     .rst_ni,
@@ -744,9 +750,10 @@ module axi_llc_top #(
 
   // data storage
   axi_llc_ways #(
-    .Cfg       ( Cfg       ),
-    .way_inp_t ( way_inp_t ),
-    .way_oup_t ( way_oup_t )
+    .Cfg          ( Cfg          ),
+    .way_inp_t    ( way_inp_t    ),
+    .way_oup_t    ( way_oup_t    ),
+    .PrintSramCfg ( PrintSramCfg )
   ) i_llc_ways (
     .clk_i                ( clk_i               ),
     .rst_ni               ( rst_ni              ),

--- a/src/axi_llc_ways.sv
+++ b/src/axi_llc_ways.sv
@@ -20,7 +20,9 @@ module axi_llc_ways #(
   /// Data way request payload type definition.
   parameter type way_inp_t = logic,
   /// Data way response payload type definition.
-  parameter type way_oup_t = logic
+  parameter type way_oup_t = logic,
+  /// Whether to print SRAM configs.
+  parameter bit  PrintSramCfg = 0
 ) (
   /// Clock, positive edge triggered.
   input logic clk_i,
@@ -131,9 +133,10 @@ module axi_llc_ways #(
   // once for each way
   for (genvar j = 0; unsigned'(j) < Cfg.SetAssociativity; j++) begin : gen_data_ways
     axi_llc_data_way #(
-      .Cfg       ( Cfg       ),
-      .way_inp_t ( way_inp_t ),
-      .way_oup_t ( way_oup_t )
+      .Cfg          ( Cfg          ),
+      .way_inp_t    ( way_inp_t    ),
+      .way_oup_t    ( way_oup_t    ),
+      .PrintSramCfg ( PrintSramCfg )
     ) i_data_way (
       .clk_i,
       .rst_ni,

--- a/src/hit_miss_detect/axi_llc_tag_store.sv
+++ b/src/hit_miss_detect/axi_llc_tag_store.sv
@@ -24,7 +24,9 @@ module axi_llc_tag_store #(
   /// Type of the request payload made to the tag storage
   parameter type store_req_t = logic,
   /// Type of the response payload expected from the tag storage
-  parameter type store_res_t = logic
+  parameter type store_res_t = logic,
+  /// Whether to print SRAM configs
+  parameter bit  PrintSramCfg = 0
 ) (
   /// Clock, positive edge triggered
   input  logic       clk_i,
@@ -272,7 +274,7 @@ module axi_llc_tag_store #(
       .NumPorts    ( 32'd1                        ),
       .Latency     ( axi_llc_pkg::TagMacroLatency ),
       .SimInit     ( "none"                       ),
-      .PrintSimCfg ( 1'b1                         )
+      .PrintSimCfg ( PrintSramCfg                 )
     ) i_tag_store (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
We add two parameters, one for the config and one for `tc_sram` blocks each.

Could I please get a release with that? :smiley: 