### PR TITLE
config: Support coalesced explicit and SPM flushes

### DIFF
--- a/src/axi_llc_config.sv
+++ b/src/axi_llc_config.sv
@@ -437,18 +437,14 @@ module axi_llc_config #(
         // it also sets up the counters for state-keeping how far
         // the flush operation has progressed
         // define if the user requested a flush
-        if (|conf_regs_i.cfg_flush) begin
-          to_flush_d              = conf_regs_i.cfg_flush & ~conf_regs_i.flushed;
-        end else begin
-          to_flush_d              = conf_regs_i.cfg_spm & ~conf_regs_i.flushed;
-          conf_regs_o.flushed     = conf_regs_i.cfg_spm & conf_regs_i.flushed;
-          conf_regs_o.flushed_en  = 1'b1;
-        end
+        to_flush_d = (conf_regs_i.cfg_flush | conf_regs_i.cfg_spm) & ~conf_regs_i.flushed;
+        conf_regs_o.flushed     = conf_regs_i.cfg_spm & conf_regs_i.flushed;
+        conf_regs_o.flushed_en  = 1'b1;
         // now determine if we have something to do at all
         if (to_flush_d == '0) begin
           // nothing to flush, go to idle
           flush_state_d = FsmIdle;
-          
+          // clear the cfg_flush register.
           conf_regs_o.cfg_flush = set_asso_t'(1'b0);
         end else begin
           flush_state_d = FsmSendFlush;


### PR DESCRIPTION
The current implementation assumes that a flush is triggered either by a write to `cfg_flush` *or* to `cfg_spm`, but never to both at the same time. In particular, when reconfiguring a way from SPM to LLC while any bit of `cfg_flush` is set, this can cause this way to remain marked as `flushed` and function neither as SPM nor LLC. In our scenario, the LLC was still in bypass mode even though some ways had been configured as LLC.

Fix this by reducing the if/else block to an invariant.