### PR TITLE
LLC Config: support concurrent and non-concurrent SPM/FLUSH settings

### DIFF
--- a/src/axi_llc_config.sv
+++ b/src/axi_llc_config.sv
@@ -450,7 +450,6 @@ module axi_llc_config #(
         // the flush operation has progressed
         // define if the user requested a flush
         to_flush_d = (conf_regs_i.cfg_flush | conf_regs_i.cfg_spm) & ~conf_regs_i.flushed;
-        conf_regs_o.flushed     = conf_regs_i.cfg_spm & conf_regs_i.flushed;
         conf_regs_o.flushed_en  = 1'b1;
         // now determine if we have something to do at all
         if (to_flush_d == '0) begin
@@ -458,7 +457,11 @@ module axi_llc_config #(
           flush_state_d = FsmIdle;
           // clear the cfg_flush register.
           conf_regs_o.cfg_flush = set_asso_t'(1'b0);
+          // Apply new SPM configuration, if changed
+          conf_regs_o.flushed     = conf_regs_i.cfg_spm & conf_regs_i.flushed;
         end else begin
+          // Some ways must be flushed, update conf_reg_o.flushed
+          conf_regs_o.flushed = (conf_regs_i.cfg_flush | conf_regs_i.cfg_spm) & conf_regs_i.flushed;
           flush_state_d = FsmSendFlush;
           load_cnt      = 1'b1;
         end


### PR DESCRIPTION
### Bug Description

The current version of the LLC config module causes the FSM to **remain stuck when writing only the FLUSH register** and committing its value (e.g. LLC is currently configured with SPM=0x03, and a flush is sent on all ways).

This is due to an incorrect assignment of the `cfg_o.flushed`, in the `FsmInitState` state of the FSM.  `cfg_o.flushed` is updated taking into account only the `cfg_i.spm` register value. This causes the flush to be repeated infinite times on some ways.

### Proposed Solution

The provided solution ensures that in the above described scenario, the `cfg_o.flushed` is correctly updated at the beginning of each way-flush.
Furthermore, it ensures that when no ways have to be flushed (`to_flush_d =0`), the `cfg.flushed`  register is correctly update with the new SPM configuration.

### Test Cases

The solution provided has been tested in the following cases:

1. LLC with a certain SPM register conf committed: Flush an arbitrary number of ways:
a. If the ways to be flushed are already in SPM, they won’t be flushed and `cfg.flushed` register will maintain the old SPM configuration.
b. If some of the ways to be flushed are not in SPM, they will be flushed, and, at the end of the process, in `FsmEndFlush` state, `cfg.flushed` will be restored with the current SPM configuration. This works both for overlapping and non-overlapping SPM and FLUSH ways.
2. LLC with a certain SPM conf committed: concurrent write to SPM and FLUSH.

A series of corner cases, **even though not exhaustive**, for non-overlapping, partially overlapping and completely overlapping configs have been tested.