### PR TITLE
Fix BIST val/dit comparison in gen_tag_macros (axi_llc_tag_store)

### DIFF
--- a/src/hit_miss_detect/axi_llc_tag_store.sv
+++ b/src/hit_miss_detect/axi_llc_tag_store.sv
@@ -298,19 +298,20 @@ module axi_llc_tag_store #(
     );
 
     // comparator (XNOR)
-    assign ram_compared = tag_data_t'{
-          val: bist_pattern.val,
-          dit: bist_pattern.dit,
-          tag: (req_q.mode == axi_llc_pkg::Bist) ? bist_pattern.tag : req_q.tag
-        } ~^ ram_rdata;
-    assign tag_equ[i] = &ram_compared.tag; // valid if the stored tag equals the one looked up
-    assign tag_val[i] = ram_rdata.val;     // indicates where valid values are in the line
-    assign tag_dit[i] = ram_rdata.dit;     // indicates which tags are dirty
+    tag_t tag_compare;
+    logic i_tag_equ;
 
-    // hit detection
-    assign hit[i]        = req_q.indicator[i] & tag_val[i] & tag_equ[i];
-    // BIST also add the two bits of valid and dirty
-    assign bist_res[i]   = ram_compared.val & ram_compared.dit & tag_equ[i];
+    assign tag_compare  = (req_q.mode == axi_llc_pkg::Bist) ? bist_pattern.tag : req_q.tag;
+    assign i_tag_equ    = &(ram_rdata.tag ~^ tag_compare);
+    assign tag_equ[i]   = i_tag_equ;
+    assign tag_val[i]   = ram_rdata.val;
+    assign tag_dit[i]   = ram_rdata.dit;
+
+    assign hit[i]      = req_q.indicator[i] & tag_val[i] & tag_equ[i];
+    assign bist_res[i] = (ram_rdata.val == bist_pattern.val) &
+                         (ram_rdata.dit == bist_pattern.dit) &
+                         i_tag_equ;
+
     // assignment to wide output signal that goes to the tag output mux
     assign stored_tag[i] = ram_rdata;
   end


### PR DESCRIPTION
The original code performed a bitwise XNOR between a temporary packed struct and ram_rdata, then re-sliced the result back into a tag_data_t struct:

``` verilog
    assign ram_compared = tag_data_t'{val: ..., dit: ..., tag: ...} ~^ ram_rdata;
    assign bist_res[i]  = ram_compared.val & ram_compared.dit & tag_equ[i];
```

Per IEEE 1800-2017, `~^` on packed structs operates on the flattened bit vector. Re-slicing the result into struct fields is valid but error-prone: for single-bit fields(`val`, `dit`), I observed that even though the compilation passes, the XNOR result was consistently 0 regardless of the actual values, confirmed in simulation `(ram_rdata.val == bist_pattern.val == 1, but ram_compared.val == 0)`.
This was putting the LLC in SPM mode, as BIST was failing.

Replaced with explicit per-field comparisons:
- tag: XNOR reduction on the tag field only, with an explicit mux on Bist vs Lookup
- `val`, `dit`: == comparison directly on the relevant struct fields

Functionally equivalent for Lookup/Flush (`tag_equ` unchanged), fixes BIST result accumulation in `axi_llc_tag_pattern_gen`.