### PR TITLE
config: Simplify `flushed` handling, fix hang on flush

### DIFF
--- a/src/axi_llc_config.sv
+++ b/src/axi_llc_config.sv
@@ -448,16 +448,16 @@ module axi_llc_config #(
         // this state determines which cache way should be flushed
         // it also sets up the counters for state-keeping how far
         // the flush operation has progressed
-        // define if the user requested a flush
         to_flush_d = (conf_regs_i.cfg_flush | conf_regs_i.cfg_spm) & ~conf_regs_i.flushed;
-        conf_regs_o.flushed     = conf_regs_i.cfg_spm & conf_regs_i.flushed;
-        conf_regs_o.flushed_en  = 1'b1;
         // now determine if we have something to do at all
         if (to_flush_d == '0) begin
           // nothing to flush, go to idle
           flush_state_d = FsmIdle;
           // clear the cfg_flush register.
           conf_regs_o.cfg_flush = set_asso_t'(1'b0);
+          // reset the flushed register to SPM.
+          conf_regs_o.flushed     = conf_regs_i.cfg_spm;
+          conf_regs_o.flushed_en  = 1'b1;
         end else begin
           flush_state_d = FsmSendFlush;
           load_cnt      = 1'b1;


### PR DESCRIPTION
We need to maintain `flushed = cfg_spm` when transitioning to Idle. Other than that, updates to `flushed` in `FsmInitFlush` are superfluous: `to_flush` tracks what to flush, `FsmEndFlush` updates `flushed`.

Fixes #28, where `flushed` is wrongly updated, causing an infinite loop. Functionally equivalent to #26.