### PR TITLE
axi_llc: Make AXI ID lookup width configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 
 BENDER ?= bender
 PYTHON ?= python3
+VSIM   ?= vsim
 
 REGGEN_PATH  = $(shell $(BENDER) path register_interface)/vendor/lowrisc_opentitan/util/regtool.py
 REGGEN	     = $(PYTHON) $(REGGEN_PATH)
@@ -30,6 +31,7 @@ help:
 	@echo "-------------"
 	@echo ""
 	@echo "bin/axi_llc.vcs:                   creates the VCS executable"
+	@echo "sim_id_widths:                     simulates representative AXI ID lookup widths"
 	@echo "pickle:                            uses morty to generate a pickled version of the hardware"
 	@echo "doc:                               generates the documentation in doc/morty"
 	@echo "graph:                             generates the module hierarchy graph in doc/morty-graph"
@@ -52,7 +54,7 @@ regs:
 # QuestaSim
 # --------------
 
-.PHONY: sim_clean
+.PHONY: sim_id_widths sim_clean
 
 VLOG_ARGS += -suppress vlog-2583 -suppress vlog-13314 -suppress vlog-13233 -timescale \"1 ns / 1 ps\"
 
@@ -64,6 +66,9 @@ endef
 
 scripts/compile_vsim.tcl: Bender.yml
 	$(call generate_vsim, $@, -t rtl -t test,..)
+
+sim_id_widths: scripts/compile_vsim.tcl
+	$(VSIM) -c -do "source scripts/compile_vsim.tcl; source scripts/test_id_widths_vsim.tcl"
 
 sim_clean:
 	rm -rf scripts/compile_vsim.tcl

--- a/scripts/test_id_widths_vsim.tcl
+++ b/scripts/test_id_widths_vsim.tcl
@@ -1,0 +1,47 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+#
+# Author: Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+set regression_failed 0
+
+proc run_id_width_test {name id_width lookup_bits} {
+  global regression_failed
+
+  puts "================================================================"
+  puts "= Running AXI ID configuration: width=$id_width lookup=$lookup_bits"
+  puts "================================================================"
+
+  set transcript_name "logs/axi_llc.id_width_${name}.vsim.log"
+  file delete -force $transcript_name
+  transcript file $transcript_name
+
+  vsim -t 1ps -voptargs=+acc -sv_seed 1 \
+      -GTbAxiIdWidthFull=$id_width \
+      -GTbAxiIdLookupBits=$lookup_bits \
+      -wlf "logs/axi_llc.id_width_${name}.wlf" \
+      tb_axi_llc
+
+  onfinish stop
+  set StdArithNoWarnings 1
+  set NumericStdNoWarnings 1
+  run 100 us
+  quit -sim
+
+  transcript file {}
+  set transcript_fd [open $transcript_name r]
+  set transcript_data [read $transcript_fd]
+  close $transcript_fd
+  if {[regexp -line {^# \*\* (Error|Fatal)( \([^)]*\))?:} $transcript_data]} {
+    puts "Regression errors detected in $transcript_name"
+    set regression_failed 1
+  }
+}
+
+run_id_width_test width1_lookup1 1 1
+run_id_width_test width2_lookup1 2 1
+run_id_width_test width6_lookup2 6 2
+run_id_width_test width6_lookup4 6 4
+
+quit -code $regression_failed -f

--- a/scripts/test_id_widths_vsim.tcl
+++ b/scripts/test_id_widths_vsim.tcl
@@ -41,7 +41,10 @@ proc run_id_width_test {name id_width lookup_bits} {
 
 run_id_width_test width1_lookup1 1 1
 run_id_width_test width2_lookup1 2 1
+run_id_width_test width3_lookup3 3 3
+run_id_width_test width5_lookup3 5 3
 run_id_width_test width6_lookup2 6 2
 run_id_width_test width6_lookup4 6 4
+run_id_width_test width6_lookup5 6 5
 
 quit -code $regression_failed -f

--- a/src/axi_llc_hit_miss.sv
+++ b/src/axi_llc_hit_miss.sv
@@ -48,7 +48,9 @@ module axi_llc_hit_miss #(
   /// Way indicator, is a onehot signal with width: `Cfg.SetAssociativity`.
   parameter type                       way_ind_t = logic,
   /// Whether to print SRAM configs
-  parameter bit                        PrintSramCfg = 0
+  parameter bit                        PrintSramCfg = 0,
+  /// Number of low AXI ID bits used for miss counters.
+  parameter int unsigned               AxiIdLookupBits = 32'd0
 ) (
   /// Clock, positive edge triggered.
   input  logic     clk_i,
@@ -360,8 +362,9 @@ module axi_llc_hit_miss #(
   assign cnt_up.valid = ~desc_o.flush & miss_valid_o & miss_ready_i;
 
   axi_llc_miss_counters #(
-    .Cfg     ( Cfg    ),
-    .cnt_t   ( cnt_t  )
+    .Cfg             ( Cfg             ),
+    .AxiIdLookupBits ( AxiIdLookupBits ),
+    .cnt_t           ( cnt_t           )
   ) i_miss_counters (
     .clk_i      (      clk_i ),
     .rst_ni     (     rst_ni ),

--- a/src/axi_llc_pkg.sv
+++ b/src/axi_llc_pkg.sv
@@ -229,11 +229,6 @@ package axi_llc_pkg;
   parameter int unsigned MissCntWidth     = 32'd5;
   /// Writes are counted separately. Writes have to be in order, only one counter.
   parameter int unsigned MissCntMaxWWidth = 32'd7;
-  /// This number tells us how many bits of the slave port AXI ID are used for pointing on a counter
-  /// * Translates in 2**`UseIdBits` counters inferred.
-  /// * Set this parameter to the slave port AXI ID width if you want one counter for each AXI ID.
-  parameter int unsigned UseIdBits        = 32'd4;
-
   /// This adds a spill register in the response path of the tag stroage unit.
   /// This should be used to achieve good timing characteristics in synthsis as the longest
   /// path in the design comes out of the tag storage macros.

--- a/src/axi_llc_reg_wrap.sv
+++ b/src/axi_llc_reg_wrap.sv
@@ -189,7 +189,11 @@ module axi_llc_reg_wrap #(
   parameter type axi_addr_t     = logic[AxiAddrWidth-1:0],
   /// Dependent parameter, do **not** overwrite!
   /// Data type of set associativity wide registers
-  parameter type way_ind_t      = logic[SetAssociativity-1:0]
+  parameter type way_ind_t      = logic[SetAssociativity-1:0],
+  /// Number of low AXI ID bits used for demux tracking and miss counters.
+  /// The number of inferred bookkeeping entries grows exponentially with this value.
+  parameter int unsigned AxiIdLookupBits =
+      (AxiIdWidth < 32'd4) ? AxiIdWidth : 32'd4
 ) (
   /// Rising-edge clock of all ports.
   input logic clk_i,
@@ -264,6 +268,7 @@ module axi_llc_reg_wrap #(
     .NumLines         ( NumLines              ),
     .NumBlocks        ( NumBlocks             ),
     .AxiIdWidth       ( AxiIdWidth            ),
+    .AxiIdLookupBits  ( AxiIdLookupBits       ),
     .AxiAddrWidth     ( AxiAddrWidth          ),
     .AxiDataWidth     ( AxiDataWidth          ),
     .AxiUserWidth     ( AxiUserWidth          ),

--- a/src/axi_llc_top.sv
+++ b/src/axi_llc_top.sv
@@ -5,6 +5,8 @@
 // Author: Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>
 // Date:   30.04.2019
 
+`include "common_cells/assertions.svh"
+
 /// Contains the top_level of the axi_llc with structs as AXI connections.
 /// The standard configuration is a cache size of 512KByte with a set-associativity
 /// of 8, and line length of 8 blocks, one block equals the AXI data width of the
@@ -187,7 +189,11 @@ module axi_llc_top #(
   parameter type axi_addr_t     = logic[AxiAddrWidth-1:0],
   /// Dependent parameter, do **not** overwrite!
   /// Data type of set associativity wide registers
-  parameter type way_ind_t      = logic[SetAssociativity-1:0]
+  parameter type way_ind_t      = logic[SetAssociativity-1:0],
+  /// Number of low AXI ID bits used for demux tracking and miss counters.
+  /// The number of inferred bookkeeping entries grows exponentially with this value.
+  parameter int unsigned AxiIdLookupBits =
+      (AxiIdWidth < 32'd4) ? AxiIdWidth : 32'd4
 ) (
   /// Rising-edge clock of all ports.
   input logic clk_i,
@@ -470,7 +476,7 @@ module axi_llc_top #(
     .axi_resp_t     ( slv_resp_t             ),
     .NoMstPorts     ( 32'd2                  ),
     .MaxTrans       ( axi_llc_pkg::MaxTrans  ),
-    .AxiLookBits    ( axi_llc_pkg::UseIdBits ),
+    .AxiLookBits    ( AxiIdLookupBits         ),
     .SpillAw        ( 1'b0                   ),
     .SpillW         ( 1'b0                   ),
     .SpillB         ( 1'b0                   ),
@@ -567,13 +573,14 @@ module axi_llc_top #(
   );
 
   axi_llc_hit_miss #(
-    .Cfg          ( Cfg          ),
-    .AxiCfg       ( AxiCfg       ),
-    .desc_t       ( llc_desc_t   ),
-    .lock_t       ( lock_t       ),
-    .cnt_t        ( cnt_t        ),
-    .way_ind_t    ( way_ind_t    ),
-    .PrintSramCfg ( PrintSramCfg )
+    .Cfg             ( Cfg             ),
+    .AxiCfg          ( AxiCfg          ),
+    .AxiIdLookupBits ( AxiIdLookupBits ),
+    .desc_t          ( llc_desc_t      ),
+    .lock_t          ( lock_t          ),
+    .cnt_t           ( cnt_t           ),
+    .way_ind_t       ( way_ind_t       ),
+    .PrintSramCfg    ( PrintSramCfg    )
   ) i_hit_miss_unit (
     .clk_i,
     .rst_ni,
@@ -932,6 +939,11 @@ module axi_llc_top #(
     r_chan_unit_req:    to_way_valid[axi_llc_pkg::RChanUnit] & to_way_ready[axi_llc_pkg::RChanUnit],
     default: '0
   };
+
+  `ASSERT_INIT(AxiIdLookupBitsNonZero, AxiIdLookupBits > 32'd0,
+      "AxiIdLookupBits must be greater than zero.")
+  `ASSERT_INIT(AxiIdLookupBitsValid, AxiIdLookupBits <= AxiIdWidth,
+      "AxiIdLookupBits must not exceed AxiIdWidth.")
 
 // pragma translate_off
 `ifndef VERILATOR

--- a/src/hit_miss_detect/axi_llc_miss_counters.sv
+++ b/src/hit_miss_detect/axi_llc_miss_counters.sv
@@ -19,7 +19,9 @@ module axi_llc_miss_counters #(
   ///   logic        rw;        // 0:read, 1:write
   ///   logic        valid;     // valid, equals enable of the counter
   /// } cnt_t;
-  parameter type cnt_t  = logic
+  parameter type cnt_t  = logic,
+  /// Number of low AXI ID bits used to select a miss counter.
+  parameter int unsigned AxiIdLookupBits = 32'd0
 ) (
   /// Clock, positive edge triggered.
   input  logic clk_i,
@@ -34,7 +36,7 @@ module axi_llc_miss_counters #(
   /// One of the counters is overflowing, stall descriptor!
   output logic stall_o
 );
-  localparam int unsigned NoCounters = 2**axi_llc_pkg::UseIdBits;
+  localparam int unsigned NoCounters = 2**AxiIdLookupBits;
   // stall signal for each counter (no minus 1, because the write counter is extra )
   logic [NoCounters:0]   stall;
   logic [NoCounters-1:0] en;
@@ -55,12 +57,12 @@ module axi_llc_miss_counters #(
       en[i]     = 1'b0;
       down[i]   = 1'b0;
       // we should count up
-      if ((cnt_up_i.id[0+:axi_llc_pkg::UseIdBits] == i) && cnt_up_i.valid) begin
+      if ((cnt_up_i.id[0+:AxiIdLookupBits] == i) && cnt_up_i.valid) begin
         en[i]   = 1'b1;
       end
 
       // we should count down, or do nothing, if we are already counting up
-      if ((cnt_down_i.id[0+:axi_llc_pkg::UseIdBits] == i) && cnt_down_i.valid) begin
+      if ((cnt_down_i.id[0+:AxiIdLookupBits] == i) && cnt_down_i.valid) begin
         if (en[i] == 1'b1) begin
           en[i]   = 1'b0;
         end else begin
@@ -69,7 +71,7 @@ module axi_llc_miss_counters #(
         end
       end
       // do we have to send the descriptor to the miss pipeline?
-      if (cnt_up_i.id[0+:axi_llc_pkg::UseIdBits] == i) begin
+      if (cnt_up_i.id[0+:AxiIdLookupBits] == i) begin
         // first check the counter mapped to the id
         to_miss_o = |q_miss[i];
         // if it is a write also check if there are other writes in the miss pipeline

--- a/test/tb_axi_llc.sv
+++ b/test/tb_axi_llc.sv
@@ -17,6 +17,9 @@ module tb_axi_llc #(
   parameter int unsigned TbNumBlocks        = 32'd8,
   /// ID width of the Full AXI slave port, master port has ID `AxiIdWidthFull + 32'd1`
   parameter int unsigned TbAxiIdWidthFull   = 32'd6,
+  /// Number of low AXI ID bits used for demux tracking and miss counters.
+  parameter int unsigned TbAxiIdLookupBits  =
+      (TbAxiIdWidthFull < 32'd4) ? TbAxiIdWidthFull : 32'd4,
   /// Address width of the full AXI bus
   parameter int unsigned TbAxiAddrWidthFull = 32'd32,
   /// Data width of the full AXI bus
@@ -514,6 +517,7 @@ module tb_axi_llc #(
     .NumLines         ( TbNumLines         ),
     .NumBlocks        ( TbNumBlocks        ),
     .AxiIdWidth       ( TbAxiIdWidthFull   ),
+    .AxiIdLookupBits  ( TbAxiIdLookupBits  ),
     .AxiAddrWidth     ( TbAxiAddrWidthFull ),
     .AxiDataWidth     ( TbAxiDataWidthFull ),
     .AxiUserWidth     ( TbAxiUserWidthFull ),


### PR DESCRIPTION
Reported by @yvantor, the parameter needs to be at most AxiIdWidth.  
Additionally it is actually quite expensive to increase it, so I decided to expose it with the same defaults as before. 