### PR TITLE
trivial: Fix typos

### DIFF
--- a/src/axi_llc_burst_cutter.sv
+++ b/src/axi_llc_burst_cutter.sv
@@ -11,7 +11,7 @@
 /// onto a cache line
 /// It computes the remaining channel struct, all remaining parts of the burst
 /// which map onto other cache lines
-/// This module further caclulates the exact data way where an spm access will go to.
+/// This module further calculates the exact data way where an spm access will go to.
 module axi_llc_burst_cutter #(
   /// LLC configuration struct, with static parameters.
   parameter axi_llc_pkg::llc_cfg_t     Cfg    = axi_llc_pkg::llc_cfg_t'{default: '0},

--- a/src/axi_llc_config.sv
+++ b/src/axi_llc_config.sv
@@ -274,7 +274,7 @@ module axi_llc_config #(
   // register macros from `common_cells`
   `include "common_cells/registers.svh"
 
-  // Type for the Set Associativity puls padding
+  // Type for the Set Associativity plus padding
   localparam int unsigned SetAssoPadWidth = RegWidth - Cfg.SetAssociativity;
    
   localparam int unsigned FlushIdxWidth = cf_math_pkg::idx_width(Cfg.SetAssociativity);
@@ -284,7 +284,7 @@ module axi_llc_config #(
   logic                       clear_cnt;
   logic                       en_send_cnt, en_recv_cnt;
   logic                       load_cnt;
-  logic [Cfg.IndexLength-1:0] flush_addr,  to_recieve;
+  logic [Cfg.IndexLength-1:0] flush_addr,  to_receive;
   // Trailing zero counter signals, for flush descriptor generation.
   flush_idx_t                 to_flush_nub;
   logic                       lzc_empty;
@@ -483,7 +483,7 @@ module axi_llc_config #(
       FsmWaitFlush : begin
         // this state waits till all flush operations have exited the cache, then `FsmEndFlush`
         if (flush_desc_recv_i) begin
-          if(to_recieve == {Cfg.IndexLength{1'b0}}) begin
+          if(to_receive == {Cfg.IndexLength{1'b0}}) begin
             flush_state_d = FsmEndFlush;
           end else begin
             en_recv_cnt = 1'b1;
@@ -589,7 +589,7 @@ module axi_llc_config #(
     .load_i     ( load_cnt                ),
     .down_i     ( 1'b1                    ),
     .d_i        ( {Cfg.IndexLength{1'b1}} ),
-    .q_o        ( to_recieve              ),
+    .q_o        ( to_receive              ),
     .overflow_o ( /*not used*/            )
   );
 

--- a/src/axi_llc_hit_miss.sv
+++ b/src/axi_llc_hit_miss.sv
@@ -10,7 +10,7 @@
 /// depending on the input descriptor.
 /// The unit starts uninitialized and starts in the first cycle after each reset
 /// the tag pattern generator to perform a march X BIST onto the macros.
-/// After the BIST is finished, the macros are initialyzed to all zero.
+/// After the BIST is finished, the macros are initialized to all zero.
 /// During initialisation no descriptors can enter the unit.
 ///
 /// This unit keeps track of which cache lines are currently in use by descriptors
@@ -99,7 +99,7 @@ module axi_llc_hit_miss #(
   typedef struct packed {
     /// The request mode. What operation the tag storage should perform with the request.
     axi_llc_pkg::tag_mode_e mode;
-    /// The indicatior encodes with a hot signal, to which ways the request should be made.
+    /// The indicator encodes with a hot signal, to which ways the request should be made.
     way_ind_t               indicator;
     /// The index points to the cache line, for which the request is made.
     index_t                 index;
@@ -316,10 +316,10 @@ module axi_llc_hit_miss #(
       end
 
     ///////////////////////////////////////////////////////////////////////////////
-    // we come out of a reset, initialize the tag sram makros
+    // we come out of a reset, initialize the tag sram macros
     ///////////////////////////////////////////////////////////////////////////////
     end else begin
-      // first cycle after reset start initialization of the sram makros
+      // first cycle after reset start initialization of the sram macros
       store_req = store_req_t'{
         mode:      axi_llc_pkg::Bist,
         indicator: {Cfg.SetAssociativity{1'b1}},

--- a/src/axi_llc_pkg.sv
+++ b/src/axi_llc_pkg.sv
@@ -48,7 +48,7 @@ package axi_llc_pkg;
     int unsigned SPMLength;
   } llc_cfg_t;
 
-  /// Number of bytes transfered in an Ax transfer. Is used in `evens_t`. There they correspond to
+  /// Number of bytes transferred in an Ax transfer. Is used in `evens_t`. There they correspond to
   /// the fields labeled `*_num_bytes`. They are valid if the corresponding `active` field is `1`
   /// Can be used for bandwidth estimation.
   typedef struct packed {
@@ -57,7 +57,7 @@ package axi_llc_pkg;
     /// The `event_num_bytes` is valid/active.
     ///
     /// This corresponds to either a descriptor being handed from one LLC unit to another, or
-    /// an AXI Ax vector being transfered within the LLC.
+    /// an AXI Ax vector being transferred within the LLC.
     logic        active;
   } event_num_bytes_t;
 
@@ -229,7 +229,7 @@ package axi_llc_pkg;
   parameter int unsigned MissCntWidth     = 32'd5;
   /// Writes are counted separately. Writes have to be in order, only one counter.
   parameter int unsigned MissCntMaxWWidth = 32'd7;
-  /// This adds a spill register in the response path of the tag stroage unit.
+  /// This adds a spill register in the response path of the tag storage unit.
   /// This should be used to achieve good timing characteristics in synthsis as the longest
   /// path in the design comes out of the tag storage macros.
   /// `0`: no spill register

--- a/src/axi_llc_refill_unit.sv
+++ b/src/axi_llc_refill_unit.sv
@@ -7,7 +7,7 @@
 
 /// Houses the components for the refill operation.
 /// Is Ar/R Axi Master and refills lines to the different cache ways.
-/// Descripors enter, go to the ar master, then to a fifo, then to r master, then leave.
+/// Descriptors enter, go to the ar master, then to a fifo, then to r master, then leave.
 module axi_llc_refill_unit #(
   /// Static LLC configuration parameters.
   parameter axi_llc_pkg::llc_cfg_t Cfg = axi_llc_pkg::llc_cfg_t'{default: '0},
@@ -30,7 +30,7 @@ module axi_llc_refill_unit #(
   input logic test_i,
   /// Descriptor payload input. Comes from the eviction pipeline.
   input desc_t desc_i,
-  /// Input descriptor is vaild.
+  /// Input descriptor is valid.
   input logic desc_valid_i,
   /// Module is ready to accept a descriptor.
   output logic desc_ready_o,

--- a/src/axi_llc_top.sv
+++ b/src/axi_llc_top.sv
@@ -810,7 +810,7 @@ module axi_llc_top #(
     .mst_resp_i  ( mst_resp_i                 )
   );
 
-  // Events output track successfull handshakes at different `axi_llc` units.
+  // Events output track successful handshakes at different `axi_llc` units.
   // Function definition see `axi_llc_pkg`.
   assign axi_llc_events_o = axi_llc_pkg::events_t'{
     aw_slv_transfer:    axi_llc_pkg::event_num_bytes(

--- a/src/eviction_refill/axi_llc_ax_master.sv
+++ b/src/eviction_refill/axi_llc_ax_master.sv
@@ -35,19 +35,19 @@ module axi_llc_ax_master #(
   /// AR channel: axi_llc_pkg::RefilUnit
   parameter axi_llc_pkg::cache_unit_e  cache_unit = axi_llc_pkg::EvictUnit
 ) (
-  /// Clock, poitive edge triggered.
+  /// Clock, positive edge triggered.
   input logic clk_i,
   /// Asynchronous reset, active low.
   input logic rst_ni,
-  /// Input descripor payload.
+  /// Input descriptor payload.
   input desc_t desc_i,
   /// Input descriptor is valid.
   input logic desc_valid_i,
   /// `axi_llc_ax_master` is ready to accept an descriptor.
   output logic desc_ready_o,
-  /// Output descriptor paylaod.
+  /// Output descriptor payload.
   output desc_t desc_o,
-  /// Output descripor is valid .
+  /// Output descriptor is valid .
   output logic desc_valid_o,
   /// Next unit is ready to accept the output descriptor.
   input logic desc_ready_i,

--- a/src/hit_miss_detect/axi_llc_lock_box_bloom.sv
+++ b/src/hit_miss_detect/axi_llc_lock_box_bloom.sv
@@ -8,7 +8,7 @@
 /// This module implements the locking with a bloom filter
 /// Seeding Parameters are at the default of the `cb_filter` module for
 /// number of hashes and respective seeds
-/// unlock happens from anoter unit and is registered in a FIFO
+/// unlock happens from another unit and is registered in a FIFO
 /// the `rr_arb_tree` then merges the unlock requests onto the bloom decrement
 module axi_llc_lock_box_bloom #(
   /// Static LLC parameter configuration struct.
@@ -33,7 +33,7 @@ module axi_llc_lock_box_bloom #(
   input  logic  lock_req_i,
   /// This signal indicates that the lookup performed from `lock_i` Found a locked cache line.
   /// This means that another descriptor is currently using the cacheline.
-  /// Wait with asserting `lock_req_i` untill this is `'0`;
+  /// Wait with asserting `lock_req_i` until this is `'0`;
   output logic  locked_o,
   /// Unlock payload from the write unit.
   input  lock_t w_unlock_i,

--- a/src/hit_miss_detect/axi_llc_miss_counters.sv
+++ b/src/hit_miss_detect/axi_llc_miss_counters.sv
@@ -82,7 +82,7 @@ module axi_llc_miss_counters #(
     end
   end
   // assignment of the inputs to the write counter
-  // this assignment was calculated using a karnot diagramm
+  // this assignment was calculated using a Karnaugh map
   assign en_w = ( ~cnt_up_i.rw     & cnt_down_i.rw  &   cnt_down_i.valid ) |
                 ( ~cnt_up_i.valid  & cnt_down_i.rw  &   cnt_down_i.valid ) |
                 (  cnt_up_i.rw     & cnt_up_i.valid &  ~cnt_down_i.rw    ) |

--- a/src/hit_miss_detect/axi_llc_tag_pattern_gen.sv
+++ b/src/hit_miss_detect/axi_llc_tag_pattern_gen.sv
@@ -20,7 +20,7 @@ module axi_llc_tag_pattern_gen #(
   parameter axi_llc_pkg::llc_cfg_t Cfg = axi_llc_pkg::llc_cfg_t'{default: '0},
   /// Pattern type for generation.
   parameter type pattern_t = logic,
-  /// Way indicator type. Each way is checked indiviually. Bit position id the index of the way.
+  /// Way indicator type. Each way is checked individually. Bit position id the index of the way.
   parameter type way_ind_t = logic,
   /// Cache line index type (macro address).
   parameter type index_t   = logic

--- a/src/hit_miss_detect/axi_llc_tag_store.sv
+++ b/src/hit_miss_detect/axi_llc_tag_store.sv
@@ -10,7 +10,7 @@
 /// `axi_llc_pkg::Bist`:
 ///   The pattern gets written or read to all macros, BIST resulte gets activated
 /// `axi_llc_pkg::Flush`:
-///   Perform a way trageted eviction, the tag is written in with all zero.
+///   Perform a way targeted eviction, the tag is written in with all zero.
 /// `axi_llc_pkg::Lookup`:
 ///   Perform a tag lookup in all non SPM ways, hit/eviction gets set if needed.
 ///   Writes the tag into the macro if needed.

--- a/test/tb_axi_llc.sv
+++ b/test/tb_axi_llc.sv
@@ -463,7 +463,7 @@ module tb_axi_llc #(
       // in the scoreboard of the memory and X in the CPU memory.
       if (cpu_byte !== 8'hxx) begin
         assert (cpu_byte === mem_byte) /*$display("Pass addr: %h", compare_addr);*/ else
-          $error("At addr: %h differeing memory values are encoutered! \n CPU: %h \n MEM: %h",
+          $error("At addr: %h differing memory values are encountered! \n CPU: %h \n MEM: %h",
               compare_addr, cpu_byte, mem_byte);
       end
       compare_addr++;


### PR DESCRIPTION
This probably misses some, these were generated with the 'typos' tool. Plus a fix of Karnot diagram -> Karnaugh map. Not sure if this is a German-ism, but I haven't heard of Karnot before.